### PR TITLE
chore: add keep_vars to wrangler config to prevent secrets from exploding

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,10 +17,9 @@
 		}
 	],
 	"triggers": {
-		"crons": [
-			"0 2 * * 2-6"
-		]
-	}
+		"crons": ["0 2 * * 2-6"]
+	},
+	"keep_vars": true
 	/**
 	 * Smart Placement
 	 * Docs: https://developers.cloudflare.com/workers/configuration/smart-placement/#smart-placement


### PR DESCRIPTION
## Overview

This pull request adds `keep_vars` option in Wrangler config to persist non-secret variables between deployments.