### PR TITLE
fix: replace escaped newline when importing private key

### DIFF
--- a/src/lib/google.ts
+++ b/src/lib/google.ts
@@ -18,6 +18,7 @@ function pemToArrayBuffer(pem: string) {
   const base64 = pem
     .replace(/-----BEGIN PRIVATE KEY-----/, '')
     .replace(/-----END PRIVATE KEY-----/, '')
+    .replace(/\\n/g, '')
     .replace(/\s+/g, '');
 
   const binary = atob(base64);


### PR DESCRIPTION
## Overview

This pull request fixes private key import behavior by replacing escaped newline characters `\\n` with empty string, since the private key is stored that way.