### PR TITLE
feat: add debugger during reminder failure

### DIFF
--- a/src/scheduler/reminder.ts
+++ b/src/scheduler/reminder.ts
@@ -40,7 +40,7 @@ export default async function (env: Env) {
   await Promise.all(
     Object.entries(reservations).map(async ([key, reservations]) => {
       const text = `*🔔 Environment Reservation Reminder*
-      
+
 Hello {user}! This is a friendly reminder that you still have the following environment(s) reserved:
 
 ${reservations
@@ -68,7 +68,7 @@ Please don't forget to unreserve the environment(s) with the \`/unreserve\` comm
 - Restoring environment variables
 - Clean temporary files`;
 
-      await fetch(
+      const response = await fetch(
         `https://chat.googleapis.com/v1/spaces/${env.DAILY_GOOGLE_SPACE}/messages`,
         {
           method: 'POST',
@@ -84,6 +84,16 @@ Please don't forget to unreserve the environment(s) with the \`/unreserve\` comm
           }),
         },
       );
+
+      if (!response.ok) {
+        const body = await response.json();
+
+        console.error(body);
+
+        throw new Error(
+          `Failed to send 'direct message' to channel. Response returned ${response.status}`,
+        );
+      }
     }),
   );
 }


### PR DESCRIPTION
## Overview

This pull request adds debugger statements when sending reminder to debug possible failures, since it silently fails right now.