### PR TITLE
chore: add wrangler vars

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,12 +38,6 @@ app.post('/', async (c) => {
   return c.json({});
 });
 
-app.get('/send-reminder', async (c) => {
-  await sendReminder(c.env);
-
-  return c.json({ message: 'Reminder sent!' });
-});
-
 app.onError((e, c) => {
   console.error(e);
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -19,7 +19,10 @@
 	"triggers": {
 		"crons": ["0 2 * * 2-6"]
 	},
-	"keep_vars": true
+	"keep_vars": true,
+	"vars": {
+		"GOOGLE_SPACE": "AAQA-yhQs0Y"
+	}
 	/**
 	 * Smart Placement
 	 * Docs: https://developers.cloudflare.com/workers/configuration/smart-placement/#smart-placement


### PR DESCRIPTION
## Overview

This pull request introduces 2 changes:

1. Removes `/send-reminder` tester code. It works!
2. Registers `GOOGLE_SPACE` env var to `wrangler.jsonc` since `keep_vars` doesn't work (?)