### PR TITLE
fix: send the unaliased name to writeFn

### DIFF
--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -108,7 +108,7 @@ ${Services.map((env) => `- \`${env}\``).join('\n')}`,
 
       return fn(c.env.ENVIRONMENT_RESERVATION, meta, {
         environment,
-        service: svc,
+        service: exist[0],
       });
     }),
   );


### PR DESCRIPTION
## Overview

This pull request fixes `/reserve` and `/unreserve` command when dealing with service alias such as `fe` and `front-end` by sending the correct unaliased name to `WriteFn`